### PR TITLE
Fix navbar toggler for Bootstrap 5

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,8 +27,8 @@
           <button
             class="navbar-toggler"
             type="button"
-            data-toggle="collapse"
-            data-target="#navbarID"
+            data-bs-toggle="collapse"
+            data-bs-target="#navbarID"
             aria-controls="navbarID"
             aria-expanded="false"
             aria-label="Toggle navigation"
@@ -58,11 +58,7 @@
         </div>
       </nav>
 
-      <!-- (Optional) - Place this js code after initializing bootstrap.min.js or bootstrap.bundle.min.js -->
-      <script>
-        var triggerEl = document.querySelector("#navId a");
-        bootstrap.Tab.getInstance(triggerEl).show(); // Select tab by name
-      </script>
+      
     </header>
     <main>
       <div class="row justify-content-center pt-5 pb-5">

--- a/contact.html
+++ b/contact.html
@@ -27,8 +27,8 @@
           <button
             class="navbar-toggler"
             type="button"
-            data-toggle="collapse"
-            data-target="#navbarID"
+            data-bs-toggle="collapse"
+            data-bs-target="#navbarID"
             aria-controls="navbarID"
             aria-expanded="false"
             aria-label="Toggle navigation"
@@ -58,11 +58,7 @@
         </div>
       </nav>
 
-      <!-- (Optional) - Place this js code after initializing bootstrap.min.js or bootstrap.bundle.min.js -->
-      <script>
-        var triggerEl = document.querySelector("#navId a");
-        bootstrap.Tab.getInstance(triggerEl).show(); // Select tab by name
-      </script>
+      
     </header>
     <main>
       <div class="row justify-content-center pt-5 pb-5">

--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
           <button
             class="navbar-toggler"
             type="button"
-            data-toggle="collapse"
-            data-target="#navbarID"
+            data-bs-toggle="collapse"
+            data-bs-target="#navbarID"
             aria-controls="navbarID"
             aria-expanded="false"
             aria-label="Toggle navigation"
@@ -55,11 +55,7 @@
         </div>
       </nav>
 
-      <!-- (Optional) - Place this js code after initializing bootstrap.min.js or bootstrap.bundle.min.js -->
-      <script>
-        var triggerEl = document.querySelector("#navId a");
-        bootstrap.Tab.getInstance(triggerEl).show(); // Select tab by name
-      </script>
+      
     </header>
     <main>
       <div class="container justify-content-md-center mt-5">
@@ -68,7 +64,7 @@
             class="card shadow p-3 mb-5 bg-body rounded"
             style="width: 18rem"
           >
-            <img src=".//css/timur.jpg" class="card-img-top" alt="..." />
+            <img src="./css/timur.jpg" class="card-img-top" alt="..." />
             <div class="card-body">
               <h5 class="card-title">Бизнес решения</h5>
               <h6 class="card-subtitle mb-2 text-muted">Уголёк</h6>
@@ -83,7 +79,7 @@
             class="card shadow p-3 mb-5 bg-body rounded"
             style="width: 18rem"
           >
-            <img src=".//css/timur_krut.jpg" class="card-img-top" alt="..." />
+            <img src="./css/timur_krut.jpg" class="card-img-top" alt="..." />
             <div class="card-body">
               <h5 class="card-title">Добрый</h5>
               <h6 class="card-subtitle mb-2 text-muted">Трудолюбивый</h6>
@@ -98,7 +94,7 @@
             style="width: 18rem"
           >
             <img
-              src=".//css/army.png"
+              src="./css/army.png"
               class="card-img-top"
               style="width: 255px; height: 340px"
               alt="..."
@@ -127,7 +123,7 @@
               <h2 class="text-center mb-4">О Тимуре Ифторове</h2>
               <div class="row">
                 <div class="col-md-4">
-                  <img src=".//css/timur-photo.jpg" alt="Тимур Ифторов" class="img-fluid rounded-circle mb-3">
+                  <img src="./css/timur-photo.jpg" alt="Тимур Ифторов" class="img-fluid rounded-circle mb-3">
                 </div>
                 <div class="col-md-8">
                   <h3>Профессиональный опыт</h3>


### PR DESCRIPTION
## Summary
- use Bootstrap 5 data-bs-* attributes for navbar toggler
- remove unused nav script
- clean image paths

## Testing
- `npx htmlhint index.html about.html contact.html` (fails: 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_689b75edb5348332b53bf9c6be5887ec